### PR TITLE
Fixed typo in About : Updated to refer to What To Do app

### DIFF
--- a/inst/app/text/acknowledge-ncc.md
+++ b/inst/app/text/acknowledge-ncc.md
@@ -1,1 +1,1 @@
-The Where To Work application is proudly developed by the [Nature Conservancy of Canada](https://natureconservancy.ca/).
+The What To Do application is proudly developed by the [Nature Conservancy of Canada](https://natureconservancy.ca/).


### PR DESCRIPTION
Updated text/acknowledge-ncc.md file to refer to` What To Do` app instead of `Where To Work`.

- [x] Closed #22
- [x] Can Merge with main